### PR TITLE
Make cardinalities' parsing more tolerant

### DIFF
--- a/grammars/mocodo.cson
+++ b/grammars/mocodo.cson
@@ -16,7 +16,7 @@
 				'name': 'markup.italic.mocodo'
 			}
 			{
-				'match': '_?[01][1N][><]?'
+				'match': '(_11|..)[<>]?'
 				'name': 'constant.numeric.mocodo'
 			}
 			{


### PR DESCRIPTION
This is based on mocodo/association.py, line 13:

```python
match_leg = re.compile(r"((?:_11|..)[<>]?\s+(?:\[.+?\]\s+)?)(.+)").match
```